### PR TITLE
fix: 注册公开路由需传permission_callback参数

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -143,11 +143,13 @@ class WPD_Douban
         register_rest_route('v1', '/movies', array(
             'methods' => 'GET',
             'callback' => [$this, 'get_subjects'],
+            'permission_callback' => '__return_true',
         ));
 
         register_rest_route('v1', '/movie/genres', array(
             'methods' => 'GET',
             'callback' => [$this, 'get_genres'],
+            'permission_callback' => '__return_true',
         ));
     }
 


### PR DESCRIPTION
参见：https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-custom-endpoints/#permissions-callback